### PR TITLE
Release v1.0.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 /pkg/
 /spec/reports/
 /tmp/
+/*.gem
 
 # rspec failure tracking
 .rspec_status

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,36 @@
+PATH
+  remote: .
+  specs:
+    search_mac_address (1.0.2)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    diff-lcs (1.6.2)
+    rake (13.3.1)
+    rspec (3.13.2)
+      rspec-core (~> 3.13.0)
+      rspec-expectations (~> 3.13.0)
+      rspec-mocks (~> 3.13.0)
+    rspec-core (3.13.6)
+      rspec-support (~> 3.13.0)
+    rspec-expectations (3.13.5)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.13.0)
+    rspec-mocks (3.13.7)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.13.0)
+    rspec-support (3.13.7)
+
+PLATFORMS
+  arm64-darwin-24
+  ruby
+
+DEPENDENCIES
+  bundler (>= 1.16)
+  rake (>= 10.0)
+  rspec (>= 3.0)
+  search_mac_address!
+
+BUNDLED WITH
+   2.5.7

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # SearchMacAddress
-SearchMacAddress gems helps you to get the lists of the Mac Address of your system. It also provides a way to get a Mac Address, encode and decode it.
+SearchMacAddress helps you discover the IP addresses available on the current machine. It works in Ruby and Ruby on Rails applications and is designed to behave consistently on macOS, Linux, and Windows.
 
 ## Installation
 
@@ -19,22 +19,32 @@ Or install it yourself as:
 
 ## Usage
 
-To get set of mac addresses available on your system, use following code
+To get the list of usable IP addresses available on your system:
 ```
 SearchMacAddress::Filter.all_addr
 ```
 
-To get the mac address of your system, use following code
+You can also call the more explicit method name:
+```
+SearchMacAddress::Filter.all_ip_addr
+```
+
+To get the primary IP address of your system:
+```
+SearchMacAddress::Filter.ip_addr
+```
+
+The legacy method below is still supported for backward compatibility and now returns the primary IP address:
 ```
 SearchMacAddress::Filter.mac_addr
 ```
 
-To get encoded mac address inoder to keep it secure somewhere, use following code 
+To get an encoded version of the primary IP address:
 ```
 SearchMacAddress::Filter.encode
 ```
 
-To decode the mac address, supply encoded data to the decode()
+To decode the encoded IP address, supply encoded data to `decode()`:
 ```
 SearchMacAddress::Filter.decode(encoded_addr)
 ```

--- a/lib/search_mac_address.rb
+++ b/lib/search_mac_address.rb
@@ -4,34 +4,30 @@ require "base64"
 
 module SearchMacAddress
   class Filter
-    def self.all_addr
-      SearchMacAddress::AddrMac.get_physical_address
-    end
-
-    def self.mac_addr
-      addresses = all_addr
-      if addresses
-        return addresses.first 
-      else
-        nil
+    class << self
+      def all_ip_addr
+        SearchMacAddress::AddrMac.get_ip_addresses
       end
-    end
 
-    def self.encode
-      rec = mac_addr
-      if rec
-        Base64.urlsafe_encode64(rec)
-      else
-        ''
+      def all_addr
+        all_ip_addr
       end
-    end
 
-    def self.decode(addr)
-      rec = addr
-      if rec
-        Base64.urlsafe_decode64(rec)
-      else
-        ''
+      def ip_addr
+        all_ip_addr.first
+      end
+
+      def mac_addr
+        ip_addr
+      end
+
+      def encode
+        rec = ip_addr
+        rec ? Base64.urlsafe_encode64(rec) : ''
+      end
+
+      def decode(addr)
+        addr ? Base64.urlsafe_decode64(addr) : ''
       end
     end
   end

--- a/lib/search_mac_address/addr_mac.rb
+++ b/lib/search_mac_address/addr_mac.rb
@@ -1,42 +1,159 @@
+require 'ipaddr'
 require 'socket'
 
 module SearchMacAddress
   class AddrMac
+    PHYSICAL_INTERFACE_PATTERN = /\A(en|eth|ens|eno|enp|wlan|wlp|wifi|wl|lan)\w*/i.freeze
+    VIRTUAL_INTERFACE_PATTERN = /\A(lo|loopback|docker|br-|veth|virbr|vmnet|utun|tun|tap|awdl|llw|anpi|gif|stf|bridge|ap)\w*/i.freeze
+
     class << self
       def get_physical_address
-        res = by_socket
-        if res.any?
-          return res
+        get_ip_addresses
+      end
+
+      def get_ip_addresses
+        by_socket.then do |addresses|
+          return addresses if addresses.any?
         end
 
-        rec = by_popen
-        if rec.any?
-          return rec
-        end
-
-        p "Rec not found"  
+        by_popen
       end
 
       def by_socket
-        addresses = []
-        Socket.getifaddrs.each do |get_addr|
-          next unless get_addr.addr.pfamily == Socket::PF_PACKET if Socket.const_defined?(:PF_PACKET)
-          addr = get_addr.addr.inspect_sockaddr[/hwaddr=([\h:]+)/,1]
-          addresses << addr if addr != "00:00:00:00:00:00"
+        interfaces = Socket.getifaddrs.filter_map do |ifaddr|
+          next unless usable_ip_interface?(ifaddr)
+
+          {
+            name: ifaddr.name.to_s,
+            ip: normalized_ip(ifaddr.addr.ip_address),
+            family: ifaddr.addr.ipv4? ? :ipv4 : :ipv6
+          }
         end
-        return addresses
+
+        ordered_unique_ips(interfaces)
+      rescue StandardError
+        []
       end
 
       def by_popen
-        regex = %r<(?:hwaddr|:)\s+((?:[0-9a-f]{1,2}[-:]){5}[0-9a-f]{1,2})\s*$>i
-        res =
-          begin
-            IO.popen('ifconfig'){|fd| fd.readlines}
-          rescue
-            IO.popen('ipconfig /all'){|fd| fd.readlines}
+        ordered_unique_ips(parse_output(command_output('ifconfig'))).tap do |addresses|
+          return addresses if addresses.any?
+        end
+
+        ordered_unique_ips(parse_output(command_output('ipconfig /all')))
+      end
+
+      private
+
+      def usable_ip_interface?(ifaddr)
+        addr = ifaddr.addr
+        return false unless addr&.ip?
+
+        ip = parse_ip(addr.ip_address)
+        return false unless ip
+        return false if excluded_ip?(ip)
+
+        true
+      end
+
+      def parse_output(output)
+        return [] if output.to_s.empty?
+
+        interfaces = []
+        current_name = nil
+
+        output.each_line do |line|
+          current_name = interface_name_from(line) || current_name
+          next unless relevant_ip_line?(line)
+
+          extract_ips(line).each do |ip|
+            parsed_ip = parse_ip(ip)
+            next unless parsed_ip
+            next if excluded_ip?(parsed_ip)
+
+            interfaces << {
+              name: current_name.to_s,
+              ip: normalized_ip(parsed_ip.to_s),
+              family: parsed_ip.ipv4? ? :ipv4 : :ipv6
+            }
           end
-        addresses = res.map{|row| regex.match( row )[1] rescue nil }.compact
-        return addresses
+        end
+
+        interfaces
+      end
+
+      def extract_ips(line)
+        if line.match?(/\binet6\b/i) || line.match?(/IPv6 Address/i)
+          line.scan(/\b(?:[0-9a-f]{0,4}:){2,7}[0-9a-f]{0,4}\b/i).first(1)
+        else
+          line.scan(/\b(?:\d{1,3}\.){3}\d{1,3}\b/).first(1)
+        end
+      end
+
+      def interface_name_from(line)
+        unix_name = line[/\A([A-Za-z0-9:_\-.]+):/, 1]
+        return unix_name if unix_name
+
+        windows_name = line[/adapter\s+(.+?):\s*\z/i, 1]
+        return windows_name if windows_name
+
+        nil
+      end
+
+      def relevant_ip_line?(line)
+        line.match?(/\binet6?\b/i) || line.match?(/IPv[46] Address/i)
+      end
+
+      def ordered_unique_ips(interfaces)
+        interfaces
+          .uniq { |entry| entry[:ip] }
+          .sort_by { |entry| [-priority_for(entry), entry[:name], entry[:ip]] }
+          .map { |entry| entry[:ip] }
+      end
+
+      def priority_for(entry)
+        score = 0
+        score += 100 if entry[:family] == :ipv4
+        score += 20 if entry[:name].match?(PHYSICAL_INTERFACE_PATTERN)
+        score -= 40 if entry[:name].match?(VIRTUAL_INTERFACE_PATTERN)
+        score
+      end
+
+      def command_output(command)
+        IO.popen(command, err: File::NULL, &:read)
+      rescue StandardError
+        ''
+      end
+
+      def parse_ip(ip)
+        IPAddr.new(normalized_ip(ip))
+      rescue IPAddr::InvalidAddressError, NoMethodError
+        nil
+      end
+
+      def normalized_ip(ip)
+        ip.to_s.split('%').first
+      end
+
+      def link_local?(ip)
+        ip.ipv4? ? ip.to_s.start_with?('169.254.') : ip.to_s.downcase.start_with?('fe80:')
+      end
+
+      def excluded_ip?(ip)
+        ip.loopback? || unspecified?(ip) || multicast?(ip) || link_local?(ip)
+      end
+
+      def unspecified?(ip)
+        value = ip.to_s.downcase
+        value == '0.0.0.0' || value == '::'
+      end
+
+      def multicast?(ip)
+        value = ip.to_s.downcase
+        return value.start_with?('ff') if ip.ipv6?
+
+        first_octet = value.split('.').first.to_i
+        first_octet >= 224 && first_octet <= 239
       end
     end
   end

--- a/lib/search_mac_address/version.rb
+++ b/lib/search_mac_address/version.rb
@@ -1,3 +1,3 @@
 module SearchMacAddress
-  VERSION = "1.0.1".freeze
+  VERSION = "1.0.2".freeze
 end

--- a/search_mac_address.gemspec
+++ b/search_mac_address.gemspec
@@ -24,13 +24,13 @@ Gem::Specification.new do |spec|
   end
 
   spec.files         = `git ls-files -z`.split("\x0").reject do |f|
-    f.match(%r{^(test|spec|features)/})
+    f.match(%r{^(test|spec|features)/}) || f.end_with?('.gem')
   end
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 1.16"
-  spec.add_development_dependency "rake", "~> 10.0"
-  spec.add_development_dependency "rspec", "~> 3.0"
+  spec.add_development_dependency "bundler", ">= 1.16"
+  spec.add_development_dependency "rake", ">= 10.0"
+  spec.add_development_dependency "rspec", ">= 3.0"
 end

--- a/spec/search_mac_address_spec.rb
+++ b/spec/search_mac_address_spec.rb
@@ -1,9 +1,60 @@
 RSpec.describe SearchMacAddress do
-  it "has a version number" do
-    expect(SearchMacAddress::VERSION).not_to be nil
+  describe 'version' do
+    it 'has a version number' do
+      expect(SearchMacAddress::VERSION).not_to be_nil
+    end
   end
 
-  it "does something useful" do
-    expect(false).to eq(true)
+  describe SearchMacAddress::AddrMac do
+    let(:loopback_addr) { instance_double(Addrinfo, ip?: true, ip_address: '127.0.0.1', ipv4?: true) }
+    let(:wifi_addr) { instance_double(Addrinfo, ip?: true, ip_address: '192.168.1.20', ipv4?: true) }
+    let(:ethernet_addr) { instance_double(Addrinfo, ip?: true, ip_address: '10.0.0.12', ipv4?: true) }
+    let(:ipv6_link_local) { instance_double(Addrinfo, ip?: true, ip_address: 'fe80::1%en0', ipv4?: false) }
+
+    let(:loopback_if) { instance_double(Socket::Ifaddr, name: 'lo0', addr: loopback_addr) }
+    let(:wifi_if) { instance_double(Socket::Ifaddr, name: 'wlan0', addr: wifi_addr) }
+    let(:ethernet_if) { instance_double(Socket::Ifaddr, name: 'en0', addr: ethernet_addr) }
+    let(:ipv6_if) { instance_double(Socket::Ifaddr, name: 'utun0', addr: ipv6_link_local) }
+
+    it 'returns usable IPs from interfaces, prioritizing IPv4 on physical interfaces' do
+      allow(Socket).to receive(:getifaddrs).and_return([loopback_if, wifi_if, ethernet_if, ipv6_if])
+
+      expect(described_class.get_ip_addresses).to eq(%w[10.0.0.12 192.168.1.20])
+    end
+
+    it 'falls back to command parsing when socket enumeration fails' do
+      allow(Socket).to receive(:getifaddrs).and_raise(StandardError)
+      allow(described_class).to receive(:command_output).with('ifconfig').and_return(<<~OUT)
+        en0: flags=8863<UP,BROADCAST,SMART,RUNNING,SIMPLEX,MULTICAST>
+                inet 192.168.0.10 netmask 0xffffff00 broadcast 192.168.0.255
+        lo0: flags=8049<UP,LOOPBACK,RUNNING,MULTICAST>
+                inet 127.0.0.1 netmask 0xff000000
+      OUT
+
+      expect(described_class.get_ip_addresses).to eq(['192.168.0.10'])
+    end
+  end
+
+  describe SearchMacAddress::Filter do
+    before do
+      allow(SearchMacAddress::AddrMac).to receive(:get_ip_addresses).and_return(%w[10.10.17.18 192.168.1.2])
+    end
+
+    it 'returns the full list of IPs' do
+      expect(described_class.all_addr).to eq(%w[10.10.17.18 192.168.1.2])
+      expect(described_class.all_ip_addr).to eq(%w[10.10.17.18 192.168.1.2])
+    end
+
+    it 'returns the primary IP through both method names' do
+      expect(described_class.ip_addr).to eq('10.10.17.18')
+      expect(described_class.mac_addr).to eq('10.10.17.18')
+    end
+
+    it 'encodes and decodes the primary IP' do
+      encoded = described_class.encode
+
+      expect(encoded).not_to be_empty
+      expect(described_class.decode(encoded)).to eq('10.10.17.18')
+    end
   end
 end


### PR DESCRIPTION
## Summary

This PR releases `v1.0.2` and fixes the gem so it correctly returns usable IP addresses across macOS, Linux, and Windows.

## Changes

- fixed IP discovery logic for modern environments
- filtered out loopback, link-local, and other non-usable addresses
- prioritized physical-interface IPv4 addresses for the primary result
- kept `mac_addr` as a backward-compatible alias to the primary IP
- added `all_ip_addr` and `ip_addr` helper methods
- updated README usage examples
- added/updated tests for lookup and encode/decode behavior
- bumped gem version from `1.0.1` to `1.0.2`
- ignored local `.gem` build artifacts

## Testing

- ran `bundle exec rspec`
- verified local output on macOS using:
  - `SearchMacAddress::Filter.all_addr`
  - `SearchMacAddress::Filter.ip_addr`
  - `SearchMacAddress::Filter.mac_addr`
  - `SearchMacAddress::Filter.decode(SearchMacAddress::Filter.encode)`
